### PR TITLE
Add invalid ssh url test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from sdj_remotetools.utils import ssh_url_type
+from sdj_remotetools.utils import ssh_url_type, ArgparseArgumentError
 
 
 def test_ssh_url_type():
@@ -11,3 +11,8 @@ def test_ssh_url_type():
         }
 
     assert ssh_url_type(url) == result
+
+
+def test_ssh_url_type_invalid():
+    with pytest.raises(ArgparseArgumentError):
+        ssh_url_type('invalid')


### PR DESCRIPTION
## Summary
- extend utils tests with invalid SSH URL coverage

## Testing
- `pytest tests/test_utils.py::test_ssh_url_type_invalid -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68601b1138048333af6f2cb7d2f1f23c