### PR TITLE
Fix docstring example

### DIFF
--- a/sdj_remotetools/utils.py
+++ b/sdj_remotetools/utils.py
@@ -23,7 +23,7 @@ def get_std_consoles(highlight: bool = False) -> tuple[Console, Console]:
         A tuple of rich Console
 
         Example:
-            stdout, stderr = get_sdt_consoles(highlight=True)
+            stdout, stderr = get_std_consoles(highlight=True)
     """
     return Console(highlight=highlight), Console(stderr=True, highlight=False)
 


### PR DESCRIPTION
## Summary
- update utils docstring example to use `get_std_consoles(highlight=True)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_68601b0744cc8333807b4a82a5ac7c9c